### PR TITLE
Dog

### DIFF
--- a/ProjectLocal/FunctionB.c
+++ b/ProjectLocal/FunctionB.c
@@ -1,1 +1,3 @@
 This is test FunctionB file
+
+This is modification just for pull request.

--- a/Readme.txt
+++ b/Readme.txt
@@ -1,0 +1,2 @@
+This is test FunctionB file
+modified the file in branch "dog"


### PR DESCRIPTION
This is the pull request practice.

Why is this change needed?
The current size of rootfs in ambalink is 60MB, but if we add more packages including wifi driver and additional target packages then it will easily exceed current limit.

How does the PR address the problem?
Need to increase the partition size of ambalink rootfs to double.

What else do I need to know?
It should come up with actual partition increase from the BSP in the specific platform, such as rtos/cortex_a/bsp/cv25/AmbaiCamPartition.c
https://github.com/KeepTruckin/amba_sdk8/compare/increase_ambalink_rootfs1

Make sure that the size is limited in 120MB

compressed rootfs size by rootfs.ext
uncompressed actual rootfs size under output.oem/ambalink/target
Jira: https://k2labs.atlassian.net/browse/GSW-103

Signed-off-by: 